### PR TITLE
GitHub action test

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync with Git Server
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Set the schedule based on your needs, e.g., daily
+    - cron: '0 0 * * *'  
 
 jobs:
   sync:
@@ -15,8 +15,8 @@ jobs:
       - name: Pull from Git Server
         run: |
           git remote add main-server https://git.sammaas.com/satisfactory.git
-          git fetch git-server
-          git merge git-server/main --no-edit
+          git fetch main-server
+          git merge main-server/main --no-edit
 
       - name: Push to GitHub
         run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,25 @@
+name: Sync with Git Server
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Set the schedule based on your needs, e.g., daily
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Pull from Git Server
+        run: |
+          git remote add main-server https://git.sammaas.com/satisfactory.git
+          git fetch git-server
+          git merge git-server/main --no-edit
+
+      - name: Push to GitHub
+        run: |
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The idea behind this workflow is to keep the main git server and Github in sync. This will probably come in handy when SF save games need to be pushed to the server.  It would look like this

1. The satisfactory user has access to the git server via ssh
2.  The satisfactory user periodically(via cron) pushes save games  to the git repo on the server.
3. every hour a github action is being called, this action fetches the code(= the SF save games) from the main git server and pushes this code to Github 

at least that is the idea.
 